### PR TITLE
Upgrade to Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,9 +37,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: docker/setup-qemu-action@v1
-    - uses: docker/setup-buildx-action@v1
-    - uses: docker/metadata-action@v3
+    - uses: docker/setup-qemu-action@v2
+    - uses: docker/setup-buildx-action@v2
+    - uses: docker/metadata-action@v4
       id: meta
       with:
         images: ${{ inputs.registry }}/${{ inputs.image }}
@@ -49,13 +49,13 @@ runs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
     # (A) push = true => push image and cache to registry
-    - uses: docker/login-action@v1
+    - uses: docker/login-action@v2
       if: ${{ inputs.push == 'true' }}
       with:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}
-    - uses: docker/build-push-action@v2
+    - uses: docker/build-push-action@v3
       if: ${{ inputs.push == 'true' }}
       with:
         push: true
@@ -67,7 +67,7 @@ runs:
         cache-from: type=registry,ref=${{ inputs.registry }}/${{ inputs.image }}:buildcache
         cache-to: type=registry,ref=${{ inputs.registry }}/${{ inputs.image }}:buildcache,mode=max
     # (B) push = false => do not push image or cache to registry
-    - uses: docker/build-push-action@v2
+    - uses: docker/build-push-action@v3
       if: ${{ inputs.push != 'true' }}
       with:
         push: false


### PR DESCRIPTION
This will fix the various warnings in `docker-images`. @matthieugouel I'll let you merge. You can either change the `v1` tag to point to the latest commit, or create a `v2` tag and update the repos that use it.